### PR TITLE
Fix Creative Commons Icon

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,6 +17,6 @@
   </div>
   <div class="footer-copyright">
     <div class="container center-align">
-      Built for OpenNIC. All content &nbsp; <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img src="https://www.opennicproject.org/wp-content/uploads/2012/05/CC-BY-SA.png"></a> &nbsp; unless otherwise stated.
+      Built for OpenNIC. All content &nbsp; <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"></a> &nbsp; unless otherwise stated.
     </div>
   </div>


### PR DESCRIPTION
Fixed accidental reliance on image hosted on legacy WordPress website.

Apparently I can't push to master since it's protected, or approve myself. Alas...