### PR TITLE
Switch to IPvX toggles

### DIFF
--- a/_sass/materialize-component/_variables.scss
+++ b/_sass/materialize-component/_variables.scss
@@ -1,5 +1,5 @@
 /*** Colors ***/
-$primary-color: color("orange", "lighten-2") !default;
+$primary-color: color("blue", "lighten-2") !default;
 $primary-color-light: lighten($primary-color, 15%) !default;
 $primary-color-dark: darken($primary-color, 15%) !default;
 

--- a/index.html
+++ b/index.html
@@ -24,22 +24,49 @@ sitemap:
             		<br /><p>Want to switch? Click the blue button!</p>
             		<a href="http://wiki.opennic.org/start" class="waves-effect waves-light btn-large z-depth-0 blue" target="_blank">Find Out More!</a>
             		<br /><br />
-                <p><a href="https://servers.opennicproject.org/" target="_blank">All Servers</a> &#124; Your closest servers:</p>
-                <div id="geoip"></div>
+
+                <div class="row">
+                  <div class="col s12 m6 offset-m3">
+                    <ul class="tabs">
+                      <li class="tab col s3"><a class="active" href="#ipv4">IPv4</a></li>
+                      <li class="tab col s3"><a href="#ipv6">IPv6</a></li>
+                    </ul>
+                  </div>
+                  <div id="ipv4" class="col s12" style="margin-top: 25px;"></div>
+                  <div id="ipv6" class="col s12" style="margin-top: 25px;"></div>
+                </div>
+
+                <!--<p><a href="https://servers.opennicproject.org/" target="_blank">All Servers</a> &#124; Your closest servers:</p>
+                <div id="geoip"></div>-->
                 <script type="text/javascript">
               		jQuery( document ).ready( function() {
               			jQuery.ajax( {
-              				url: 'https://api.opennicproject.org/geoip/?jsonp&res=4&ip=&nearest',
+              				url: 'https://api.opennicproject.org/geoip/?jsonp&res=4&ip=&nearest&ipv=4',
               				method: 'GET',
               				dataType: 'jsonp',
               				beforeSend: function() {
-              					jQuery( '#geoip' ).html( 'Querying closest servers to you...<br />' );
+              					jQuery( '#ipv4' ).html( 'Querying closest servers to you...<br />' );
               				},
               				success: function( data, status, jqxhr ) {
-              					jQuery( '#geoip' ).html( '' );
+              					jQuery( '#ipv4' ).html( '' );
               					for( ip in data )
               					{
-              						jQuery( '#geoip' ).html( jQuery( '#geoip' ).html() + data[ip].ip + ' (' + data[ip].short + '): ' + data[ip].stat + '% uptime<br />' );
+              						jQuery( '#ipv4' ).html( jQuery( '#ipv4' ).html() + data[ip].ip + ' (' + data[ip].short + '): ' + data[ip].stat + '% uptime<br />' );
+              					}
+              				}
+              			} );
+                    jQuery.ajax( {
+              				url: 'https://api.opennicproject.org/geoip/?jsonp&res=4&ip=&nearest&ipv=6',
+              				method: 'GET',
+              				dataType: 'jsonp',
+              				beforeSend: function() {
+              					jQuery( '#ipv6' ).html( 'Querying closest servers to you...<br />' );
+              				},
+              				success: function( data, status, jqxhr ) {
+              					jQuery( '#ipv6' ).html( '' );
+              					for( ip in data )
+              					{
+              						jQuery( '#ipv6' ).html( jQuery( '#ipv6' ).html() + data[ip].ip + ' (' + data[ip].short + '): ' + data[ip].stat + '% uptime<br />' );
               					}
               				}
               			} );
@@ -92,7 +119,7 @@ sitemap:
 		<div class="row">
 			<div class="col s12">
 				<h3 class="white-text center-align thin">New Top-Level Domains!</h3>
-				<p class="white-text center-align">OpenNIC's TLDs grant you access a whole new space on the web. These domains can only be accessed <b><a href="http://wiki.opennic.org/start" class="white-text">using our democratic nameservers</a></b>. Once you're in, click a button below to register your free domain!</p>
+				<p class="white-text center-align">OpenNIC's TLDs grant you access to a whole new space on the web. These domains can only be accessed <b><a href="http://wiki.opennic.org/start" class="white-text">using our democratic nameservers</a></b>. Once you're in, click a button below to register your free domain!</p>
 			</div>
 		</div>
     <div class="row">
@@ -118,7 +145,7 @@ sitemap:
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://wiki.opennic.org/opennic:dot:fur" target="_blank">
+        <a href="http://www.nic.fur/" target="_blank">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.fur</center></span>
           </div>

--- a/index.html
+++ b/index.html
@@ -32,13 +32,12 @@ sitemap:
                       <li class="tab col s3"><a href="#ipv6">IPv6</a></li>
                     </ul>
                   </div>
-                  <div id="ipv4" class="col s12" style="margin-top: 25px;"></div>
+                  <div id="ipv4" class="col s12" style="margin-top: 25px;"><noscript>"Nearest server" functionality requires Javascript. <a href="https://servers.opennicproject.org/" target="_blank">Click here to see a list of servers.</a></noscript></div>
                   <div id="ipv6" class="col s12" style="margin-top: 25px;"></div>
                 </div>
 
-                <!--<p><a href="https://servers.opennicproject.org/" target="_blank">All Servers</a> &#124; Your closest servers:</p>
-                <div id="geoip"></div>-->
                 <script type="text/javascript">
+                <!--
               		jQuery( document ).ready( function() {
               			jQuery.ajax( {
               				url: 'https://api.opennicproject.org/geoip/?jsonp&res=4&ip=&nearest&ipv=4',
@@ -53,6 +52,7 @@ sitemap:
               					{
               						jQuery( '#ipv4' ).html( jQuery( '#ipv4' ).html() + data[ip].ip + ' (' + data[ip].short + '): ' + data[ip].stat + '% uptime<br />' );
               					}
+                        jQuery( '#ipv4' ).append( '<a href="https://servers.opennicproject.org/" target="_blank">More Servers...</a>' )
               				}
               			} );
                     jQuery.ajax( {
@@ -68,11 +68,12 @@ sitemap:
               					{
               						jQuery( '#ipv6' ).html( jQuery( '#ipv6' ).html() + data[ip].ip + ' (' + data[ip].short + '): ' + data[ip].stat + '% uptime<br />' );
               					}
+                        jQuery( '#ipv6' ).append( '<a href="https://servers.opennicproject.org/" target="_blank">More Servers...</a>' )
               				}
               			} );
               		} );
+                -->
               	</script>
-                <br />
                 <p><a href="{{ "/irc/" | prepend: site.baseurl }}">Want to learn more or chat with us? Click here to join our IRC channel!</a></p>
                 <br />
             </div>


### PR DESCRIPTION
Switches from the auto-detection nearest server list to two tabs, "IPv4" and "IPv6" to prevent confusion (between the two versions, by newcomers).

New functionality: 

![](https://i.moderntld.me/LR3QnG.gif)

Old:

![](https://i.moderntld.me/Mwk9ZY.png)