### PR TITLE
Fix RSS feed URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ description: > # this means to ignore newlines until "baseurl:"
     An organization of hobbyists who run an alternative DNS network,
     also provides access to domains not administered by ICANN.
 baseurl: ""
+url: "https://www.opennic.org"
 paginate: 5
 paginate_path: "/page:num/"
 color:


### PR DESCRIPTION
The RSS feed includes the code `<link>/2015/09/29/Recent-T2-Updates.html</link>` which, according to the RFC, is not a valid link for RSS feed items because of the missing `https://www.opennic.org`. This patch *should* fix this by defining the URL which is pulled into the RSS feed by `{{ post.url | prepend: site.baseurl | prepend: site.url }}`.