### PR TITLE
Update the navbar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,22 +2,22 @@
 <nav class="grey darken-4 {{ site.color.navbar }}-text z-depth-0">
     <ul id="slide-out" class="side-nav">
         <li><a href="{{ site.baseurl }}/" class="black-text">Home</a></li>
-        <li><a href="http://wiki.opennic.org/" class="black-text">Wiki</a></li>
+        <li><a href="https://wiki.opennic.org/" class="black-text">Wiki</a></li>
+        <li><a href="https://talkdotgeek.com/index.php" class="black-text">Forum</a></li>
         <li><a href="{{ "/irc/" | prepend: site.baseurl }}" class="black-text">IRC</a></li>
         <li><a href="https://servers.opennic.org/" class="black-text">Servers</a></li>
         <li><a href="{{ "/press/" | prepend: site.baseurl }}" class="black-text">Press</a></li>
         <li><a href="https://www.opennicproject.org/members/" class="black-text">Members</a></li>
-        <li><a href="http://wiki.opennic.org/" class="black-text">Get Started!</a></li>
     </ul>
     <div class="container container-large">
     <a class="brand-logo" href="{{ site.baseurl }}/" class="{{ site.color.navbar }}-text"><span class="light {{ site.color.navbar }}-text"><b>{{ site.title }}</b> {{ site.site }}</span></a>
     <ul class="right hide-on-med-and-down">
-        <li><a href="http://wiki.opennic.org/" class="{{ site.color.navbar }}-text">Wiki</a></li>
+        <li><a href="https://wiki.opennic.org/" class="{{ site.color.navbar }}-text">Wiki</a></li>
+        <li><a href="https://talkdotgeek.com/index.php" class="{{ site.color.navbar }}-text">Forum</a></li>
         <li><a href="{{ "/irc/" | prepend: site.baseurl }}" class="{{ site.color.navbar }}-text">IRC</a></li>
         <li><a href="https://servers.opennic.org/" class="{{ site.color.navbar }}-text">Servers</a></li>
         <li><a href="{{ "/press/" | prepend: site.baseurl }}" class="{{ site.color.navbar }}-text">Press</a></li>
         <li><a href="https://www.opennicproject.org/members/" class="{{ site.color.navbar }}-text">Members</a></li>
-        <li>&nbsp;&nbsp;&nbsp;<a href="http://wiki.opennic.org/" class="waves-effect waves-light btn white black-text z-depth-0">Get Started</a></li>
     </ul>
     <a href="#" data-activates="slide-out" class="button-collapse right {{ site.color.navbar }}-text"><i class="fa fa-bars" aria-hidden="true"></i></h2></a>
     </div>


### PR DESCRIPTION
Bringing some resources up to date and removed the white button, it seemed redundant alongside the blue button on the homepage and only linked to the wiki anyways. Didn't use the .geek link to the forum because of lack of SSL at the moment.

- Add forum link (https://talkdotgeek.com/index.php)
- Fix https protocol on wiki link
- Remove 'Get Started' button