### PR TITLE
Remove target="_blank"

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
   </div>
   <div class="footer-copyright">
     <div class="container center-align">
-      Built for OpenNIC. All content &nbsp; <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="CC BY-SA 3.0" src="/assets/images/CC-BY-SA.png"></a> &nbsp; unless otherwise stated. <b><a href="https://github.com/opennic/opennic-web" target="_blank" class="white-text">Help edit this site on GitHub!</a></b>
+      Built for OpenNIC. All content &nbsp; <a href="http://creativecommons.org/licenses/by-sa/3.0/"><img alt="CC BY-SA 3.0" src="/assets/images/CC-BY-SA.png"></a> &nbsp; unless otherwise stated. <b><a href="https://github.com/opennic/opennic-web" class="white-text">Help edit this site on GitHub!</a></b>
     </div>
   </div>
   <!-- Matomo -->

--- a/index.html
+++ b/index.html
@@ -22,9 +22,9 @@ sitemap:
             		<h5>Looking for an open and democratic alternative DNS root? Concerned about censorship?</h5>
                 <h5>OpenNIC might be the solution for you!</h5>
             		<br />
-            		<a href="https://wiki.opennic.org/start" class="waves-effect waves-light btn-large z-depth-0 blue" target="_blank">Find Out More!</a>
+            		<a href="https://wiki.opennic.org/start" class="waves-effect waves-light btn-large z-depth-0 blue">Find Out More!</a>
             		<br /><br />
-                <p><a href="https://servers.opennic.org/" target="_blank">All Servers</a> &#124; Your closest servers:</p>
+                <p><a href="https://servers.opennic.org/">All Servers</a> &#124; Your closest servers:</p>
                 <div id="geoip"></div>
                 <script type="text/javascript">
               		jQuery( document ).ready( function() {
@@ -96,105 +96,105 @@ sitemap:
 		</div>
     <div class="row">
       <div class="col s4 m3 l2 offset-l1">
-        <a href="https://wiki.opennic.org/opennic:dot:bbs" target="_blank">
+        <a href="https://wiki.opennic.org/opennic:dot:bbs">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.bbs</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="https://www.opennic.chan/" target="_blank">
+        <a href="https://www.opennic.chan/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.chan</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://be.libre/" target="_blank">
+        <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.dyn</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://nic.fur/" target="_blank">
+        <a href="http://nic.fur/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.fur</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://be.libre/" target="_blank">
+        <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.geek</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2 offset-l1">
-        <a href="http://be.libre/" target="_blank">
+        <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.gopher</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://be.libre/" target="_blank">
+        <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.indy</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://be.libre/" target="_blank">
+        <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.libre</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://register.neo/" target="_blank">
+        <a href="http://register.neo/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.neo</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://register.null/" target="_blank">
+        <a href="http://register.null/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.null</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2 offset-l1">
-        <a href="http://opennic.o/" target="_blank">
+        <a href="http://opennic.o/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.o</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://be.libre/" target="_blank">
+        <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.oss</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://opennic.oz/" target="_blank">
+        <a href="http://opennic.oz/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.oz</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://be.libre/" target="_blank">
+        <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.parody</center></span>
           </div>
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://be.libre/" target="_blank">
+        <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.pirate</center></span>
           </div>
@@ -206,7 +206,7 @@ sitemap:
     </div>
     <div class="row">
       <div class="col s12">
-        <p class="white-text center-align">Anybody with the right experience can apply to run their own TLD on our network! <b><a class="white-text" href="https://wiki.opennic.org/opennic/creating_new_tlds" target="_blank">Learn More</a></b>.</p>
+        <p class="white-text center-align">Anybody with the right experience can apply to run their own TLD on our network! <b><a class="white-text" href="https://wiki.opennic.org/opennic/creating_new_tlds">Learn More</a></b>.</p>
       </div>
     </div>
   <br /><br />


### PR DESCRIPTION
Removing target="_blank" from all links. Should additionally resolve #18.

Additional reasoning:
- https://developers.google.com/web/tools/lighthouse/audits/noopener
> When your page links to another page using target="_blank", the new page runs on the same process as your page. If the new page is executing expensive JavaScript, your page's performance may also suffer. [. . .] On top of this, target="_blank" is also a security vulnerability. The new page has access to your window object via window.opener, and it can navigate your page to a different URL using window.opener.location = newURL.
- https://css-tricks.com/use-target_blank/
> target="_blank" is a change in default behavior. Links opening within the same page is the default behavior [. . .] it is safe to assume most users are most comfortable with the default behavior.