### PR TITLE
Force wrap the cryptocurrency addresses

### DIFF
--- a/_i18n/en/index.html
+++ b/_i18n/en/index.html
@@ -276,9 +276,9 @@
         <br /><br />
   			<h3 class="center-align thin">Donate</h3>
   			<p class="center-align">We provide all this completely free of charge! Please, if you are able, consider running a Tier 2 server or make a donation:</p>
-  			<p class="center-align">BTC: <b>1yM2wmPrRLSXkatn5oFLjhpXzTwDvNCpp</b><br />
-                                ETH: <b>0x8111dc2100a2aCA8138c49B4A10766eF481530a6</b><br />
-			        XMR: <b>45ddJYG1m6g21pJabJS5dvJDe8mW5obu9QreK7dxAMgJCGNP1A3J6Cub8zGic9pKbjXcwSghzFTr4RmGta5xVhsHNtZpJAK</b></p>
+  			<p class="center-align">BTC: <span class="cryptoaddress">1yM2wmPrRLSXkatn5oFLjhpXzTwDvNCpp</span><br />
+                                ETH: <span class="cryptoaddress">0x8111dc2100a2aCA8138c49B4A10766eF481530a6</span><br />
+			        XMR: <span class="cryptoaddress">45ddJYG1m6g21pJabJS5dvJDe8mW5obu9QreK7dxAMgJCGNP1A3J6Cub8zGic9pKbjXcwSghzFTr4RmGta5xVhsHNtZpJAK</span></p>
         <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <p style="text-align: center;"><input name="cmd" type="hidden" value="_s-xclick"></p>
             <p style="text-align: center;"><input name="hosted_button_id" type="hidden" value="QZLYC9T3E55KW"></p>

--- a/_sass/materialize-component/_typography.scss
+++ b/_sass/materialize-component/_typography.scss
@@ -59,3 +59,8 @@ small { font-size: 75%; }
     font-size: 1.2rem;
   }
 }
+
+.cryptoaddress {
+  font-weight: bold;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Fixes #36. Force wraps the cryptocurrency addresses so they fit in the window, as shown here in a mobile viewport. Is this a good solution? https://jda.mn/dhiz9

![](https://jda.mn/dhiz9)