### PR TITLE
Allow user-zooming on mobile

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>{% if page.title %}{% t page.title %} &#124; {% t site.title %} {% t site.site %}{% else %}{% t site.title %} {% t site.site %}{% endif %}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
     {% feed_meta %}


### PR DESCRIPTION
Removes `, maximum-scale=1.0, user-scalable=no` from the `viewport` meta tag in the header. I'm not sure why this was included in the first place...

This addresses the first part of issue #38 and affects behavior on mobile browsers: prior to this commit, users were unable to two-finger zoom on the webpage. Note that nothing will change on Safari on iOS, as Apple has chosen to ignore this meta tag completely. 