### PR TITLE
Redirect to www subdomain

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,2 @@
 /members https://www.opennicproject.org/members/ 301
+https://opennic.org/* https://www.opennic.org/:splat 301!


### PR DESCRIPTION
This is the functionality we had before the server switch, and the setup Netlify recommends: https://www.netlify.com/blog/2017/02/28/to-www-or-not-www/

<!--

At this point, this website is mostly stable. Apart from updating the information already listed on the website, new information should *probably* just be put in a new/existing Wiki article instead, at https://wiki.opennic.org/

-->

<!-- here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the site here recently, so please walk us through the -->

<!-- Explain why this functionality should be added to the homepage as opposed to the wiki, etc. -->

<!--

Enter any applicable Issues this may address here. If this should close an issue listed in the tracker, use a keyword like 'closes #2', see https://help.github.com/articles/closing-issues-using-keywords/ for details.

-->
