### PR TITLE
Fix overlapping text

### DIFF
--- a/_sass/materialize-component/_variables.scss
+++ b/_sass/materialize-component/_variables.scss
@@ -75,11 +75,11 @@ $datepicker-selected-outfocus: desaturate(lighten($secondary-color, 35%), 15%) !
 /*** Global ***/
 // Media Query Ranges
 $small-screen-up: 601px !default;
-$medium-screen-up: 993px !default;
-$large-screen-up: 1201px !default;
+$medium-screen-up: 1301px !default;
+$large-screen-up: 1501px !default;
 $small-screen: 600px !default;
-$medium-screen: 992px !default;
-$large-screen: 1200px !default;
+$medium-screen: 1300px !default;
+$large-screen: 1500px !default;
 
 $medium-and-up: "only screen and (min-width : #{$small-screen-up})" !default;
 $large-and-up: "only screen and (min-width : #{$medium-screen-up})" !default;


### PR DESCRIPTION
Fixes the "logo" and navbar navigational links from overlapping on certain screen resolutions.

Current behavior: 
<img width="1080" alt="image" src="https://user-images.githubusercontent.com/3637842/41571102-457e120e-7337-11e8-93b7-a8d5e0c18608.png">

Future behavior (same as mobile): 
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/3637842/41571119-53c31cba-7337-11e8-9fd4-b838543b47ac.png">

Tested on macOS High Sierra (screen resolution: 2560 x 1600) with Safari and Chrome.