### PR TITLE
Add domain aliases

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,11 @@
 /members https://members.opennicproject.org/ 301
+
+# Redirect domain aliases to primary domain
 https://opennic.org/* https://www.opennic.org/:splat 301!
+https://opennicproject.org/* https://www.opennic.org/:splat 301!
+https://www.opennicproject.org/* https://www.opennic.org/:splat 301!
+https://opennicproject.com/* https://www.opennic.org/:splat 301!
+https://www.opennicproject.com/* https://www.opennic.org/:splat 301!
+
+# Redirect default Netlify subdomain to primary domain
+https://opennic.netlify.com/* https://www.opennic.org/:splat 301!


### PR DESCRIPTION
Redirect [www.]opennicproject.[com|org] to www.opennic.org.

The www subdomains don't yet point to Netlify, @Fusl if you could fix that we should be able to get rid of the old webservers entirely.