### PR TITLE
move furnic from TLD to peer

### DIFF
--- a/_i18n/en/index.html
+++ b/_i18n/en/index.html
@@ -140,13 +140,6 @@
         </a>
       </div>
       <div class="col s4 m3 l2">
-        <a href="http://nic.fur/">
-          <div class="card-panel white z-depth-0">
-            <span class="black-text"><center>.fur</center></span>
-          </div>
-        </a>
-      </div>
-      <div class="col s4 m3 l2">
         <a href="http://be.libre/">
           <div class="card-panel white z-depth-0">
             <span class="black-text"><center>.geek</center></span>
@@ -268,6 +261,15 @@
             <h5 class="center">New Nations</h5>
             <p><a href="http://new-nations.net/en/">New Nations</a>' TLDs provide namespaces for emerging countries, accessible anywhere via OpenNIC.<br /><a href="https://wiki.opennic.org/opennic:namespaces#peered_top-level_domains">Learn more</a>.</p>
           </div>
+        </div>
+      </div>
+      <div class="col s12 m4">
+        <div class="icon-block">
+          <h2 class="center black-text" style="height: 66px;">
+            <i class="fa fa-exchange" aria-hidden="true"></i>
+          </h2>
+          <h5 class="center">FurNIC</h5>
+          <p>Providing resolution to any <b>.fur</b> domain through all of our Tier 2 resolvers. <br /><a href="https://wiki.opennic.org/opennic:dot:fur">Learn more</a>.</p>
         </div>
       </div>
       <p class="center-align">Everything is accessible through our <a href="https://servers.opennic.org/">global network of DNS resolvers</a>. If you operate an alternative DNS root, <a href="https://wiki.opennic.org/help"> get in touch</a>!</p>


### PR DESCRIPTION
As requested, this moves the .fur TLD from TLDs to the peering section. I have no clue how to do the icon so I just chose one. If anyone can fix that, please do.