### PR TITLE
Create 2023-01-09-Server-Outage.md

### DIFF
--- a/_i18n/en/_posts/2023-01-09-Server-Outage.md
+++ b/_i18n/en/_posts/2023-01-09-Server-Outage.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: "Recent extended server outage of ns14.de."
+date: 2023-01-09
+category:
+  - Server Announcement
+  - ns14.de.dns.opennic.glue
+author: Olde16
+---
+
+Due to an extended power outage in the server's area, name server 14 (de.opennic.glue.) was offline
+from about 04:45 UTC to 16:30 (04:30 pm) UTC. 
+
+The issue has been resolved and the server is back online.
+We are sorry for any inconveniences.


### PR DESCRIPTION
---
layout: post
title: "Recent extended server outage of ns14.de."
date: 2023-01-09
category:
  - Server Announcement
  - ns14.de.dns.opennic.glue
author: Olde16
---


Due to an extended power outage in the server's area, name server 14 (de.opennic.glue.) was offline
from about 04:45 UTC to 16:30 (04:30 pm) UTC. 


The issue has been resolved and the server is back online.
We are sorry for any inconveniences.